### PR TITLE
fix: io graph

### DIFF
--- a/lib/wiregasm/lib.cpp
+++ b/lib/wiregasm/lib.cpp
@@ -1855,7 +1855,7 @@ wg_iograph_packet(void *g, packet_info *pinfo, epan_dissect_t *edt, const void *
  * Output object with attributes:
  *       error   - graph cannot be constructed
  *   (m) iograph - array of graph results with attributes:
- *                  items  - graph values, zeros are skipped, if value is not a number it's next index encoded as hex string
+ *                  items  - graph values.
  */
 IoGraphResult wg_session_process_iograph(capture_file *cfile, MapInput input)
 {
@@ -1871,6 +1871,12 @@ IoGraphResult wg_session_process_iograph(capture_file *cfile, MapInput input)
 
   if (tok_interval)
     ws_strtou32(tok_interval, NULL, &interval_ms);
+
+  if (interval_ms <= 0)
+  {
+    buf.error = "The value for interval must be a positive integer";
+    return buf;
+  }
 
   for (i = graph_count = 0; i < (int)G_N_ELEMENTS(graphs); i++)
   {
@@ -1967,7 +1973,6 @@ IoGraphResult wg_session_process_iograph(capture_file *cfile, MapInput input)
     else
     {
       int idx;
-      int next_idx = 0;
 
       for (idx = 0; idx < graph->num_items; idx++)
       {
@@ -1983,16 +1988,7 @@ IoGraphResult wg_session_process_iograph(capture_file *cfile, MapInput input)
           graph->num_items
         );
 
-        /* if it's zero, don't display */
-        if (val == 0.0)
-          continue;
-
-        /* cause zeros are not printed, need to output index */
-        if (next_idx != idx) {
-          g.items.push_back(idx);
-        }
         g.items.push_back(val);
-        next_idx = idx + 1;
       }
     }
     buf.iograph.push_back(g);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -676,7 +676,10 @@ describe("Wiregasm Library - IoGraph", () => {
       error: "",
       iograph: [
         {
-          items: [4, 4, 10, 10, 10, 1, 17, 2, 30, 2],
+          items: [
+            4, 4, 10, 10, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 2,
+          ],
         },
       ],
     });
@@ -706,33 +709,98 @@ describe("Wiregasm Library - IoGraph", () => {
       error: "",
       iograph: [
         {
-          items: [479, 2, 721, 160, 424],
+          items: [479, 0, 721, 160, 424],
         },
         {
-          items: [533, 2, 775, 214, 478],
+          items: [533, 0, 775, 214, 478],
         },
         {
-          items: [711, 2976, 6950, 6270, 7914, 54, 17, 108, 30, 108],
+          items: [
+            711, 2976, 6950, 6270, 7914, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 108,
+          ],
         },
         {
-          items: [5688, 23808, 55600, 50160, 63312, 432, 17, 864, 30, 864],
+          items: [
+            5688, 23808, 55600, 50160, 63312, 432, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 864, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 864,
+          ],
         },
         {
-          items: [4, 4, 8, 10, 10, 1, 17, 2, 30, 2],
+          items: [
+            4, 4, 8, 10, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 2,
+          ],
         },
         {
-          items: [479, 1380, 1380, 1430, 1430],
+          items: [
+            479, 1380, 1380, 1430, 1430, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          ],
         },
         {
-          items: [],
+          items: [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+          ],
         },
         {
-          items: [119.75, 690, 780.125, 573, 737.4000244140625],
+          items: [
+            119.75, 690, 780.125, 573, 737.4000244140625, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          ],
         },
         {
-          items: [],
+          items: [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+          ],
         },
       ],
+    });
+  });
+  describe("IoGraph: negative cases", () => {
+    test("Missing required parameters", async () => {
+      const data = await fs.readFile("samples/http.cap");
+      const ret = wg.load("http.cap", data);
+      expect(ret.code).toEqual(0);
+      expect(() => {
+        wg.iograph({});
+      }).toThrowError("graph0 is mandatory");
+    });
+
+    test("Invalid request", async () => {
+      const data = await fs.readFile("samples/http.cap");
+      const ret = wg.load("http.cap", data);
+      expect(ret.code).toEqual(0);
+      const res = wg.iograph({ graph0: "garbage graph name" });
+      expect(res).toStrictEqual({
+        error: "",
+        iograph: [],
+      });
+    });
+
+    test("Invalid filter", async () => {
+      const data = await fs.readFile("samples/http.cap");
+      const ret = wg.load("http.cap", data);
+      expect(ret.code).toEqual(0);
+      const res = wg.iograph({ graph0: "packets", filter0: "garbage filter" });
+      expect(res).toStrictEqual({
+        error:
+          'Filter "garbage filter" is invalid - "filter" was unexpected in this context.',
+        iograph: [],
+      });
+    });
+
+    test("Invalid interval", async () => {
+      const data = await fs.readFile("samples/http.cap");
+      const ret = wg.load("http.cap", data);
+      expect(ret.code).toEqual(0);
+      const res = wg.iograph({ graph0: "packets", interval: "0" });
+      expect(res).toStrictEqual({
+        error: "The value for interval must be a positive integer",
+        iograph: [],
+      });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,13 +26,12 @@ const ALLOWED_TAP_KEYS = new Set(
   Array.from({ length: 15 }, (_, i) => `tap${i}`)
 );
 
-const ALLOWED_GRAPH_KEYS = new Set(
-  [
-    "filter", "interval",
-    ...Array.from({ length: 9 }, (_, i) => `graph${i}`),
-    ...Array.from({ length: 9 }, (_, i) => `filter${i}`),
-  ]
-);
+const ALLOWED_GRAPH_KEYS = new Set([
+  "filter",
+  "interval",
+  ...Array.from({ length: 9 }, (_, i) => `graph${i}`),
+  ...Array.from({ length: 9 }, (_, i) => `filter${i}`),
+]);
 
 /**
  * Wraps the WiregasmLib lib functionality and manages a single DissectSession
@@ -177,7 +176,11 @@ export class Wiregasm {
       throw new Error("graph0 is mandatory.");
     }
     if (!Object.keys(input).every((k) => ALLOWED_GRAPH_KEYS.has(k))) {
-      throw new Error(`Invalid arguments. Allowed keys are: ${Array.from(ALLOWED_GRAPH_KEYS).join(", ")}.`);
+      throw new Error(
+        `Invalid arguments. Allowed keys are: ${Array.from(
+          ALLOWED_GRAPH_KEYS
+        ).join(", ")}.`
+      );
     }
 
     const args = new this.lib.MapInput();


### PR DESCRIPTION
This PR fixes the io graph logic that was incorrectly filtering out zeros and resulting in incorrect graphs. Each index in the array now represents the result at a specific point in time. Index 1 corresponds to the first second, index 50 corresponds to the results at the 50th second.
An extra validation and more unit tests are added.