### PR TITLE
extend conversations

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/lib/wiregasm/bindings.cpp
+++ b/lib/wiregasm/bindings.cpp
@@ -291,8 +291,15 @@ EMSCRIPTEN_BINDINGS(Conversation) {
     .field("txb", &Conversation::txb)
     .field("rxf", &Conversation::rxf)
     .field("rxb", &Conversation::rxb)
+    .field("tx_frames_total", &Conversation::tx_frames_total)
+    .field("rx_frames_total", &Conversation::rx_frames_total)
+    .field("tx_bytes_total", &Conversation::tx_bytes_total)
+    .field("rx_bytes_total", &Conversation::rx_bytes_total)
     .field("start", &Conversation::start)
     .field("stop", &Conversation::stop)
+    .field("start_abs_time", &Conversation::start_abs_time)
+    .field("filtered", &Conversation::filtered)
+    .field("conv_id", &Conversation::conv_id)
     .field("filter", &Conversation::filter);
 }
 
@@ -305,6 +312,11 @@ EMSCRIPTEN_BINDINGS(Host) {
     .field("txb", &Host::txb)
     .field("rxf", &Host::rxf)
     .field("rxb", &Host::rxb)
+    .field("tx_frames_total", &Host::tx_frames_total)
+    .field("rx_frames_total", &Host::rx_frames_total)
+    .field("tx_bytes_total", &Host::tx_bytes_total)
+    .field("rx_bytes_total", &Host::rx_bytes_total)
+    .field("filtered", &Host::filtered)
     .field("filter", &Host::filter);
 }
 

--- a/lib/wiregasm/lib.cpp
+++ b/lib/wiregasm/lib.cpp
@@ -1665,6 +1665,10 @@ wg_session_process_tap_conv_cb(void *tapdata)
  *   (m) tap0               - First tap request
  *   (o) tap1...tap15       - Other tap requests
  *   (o) filter0...filter15 - Filter for each tap
+ *   (o) ignore_filter      - set to "1" if you want to be returned all
+ *                            packets, even ones that do not pass the filter.
+ *                            The packets will be marked as "filtered" in the
+ *                            output.
  *
  * Output object with attributes:
  *   (m) taps  - array of object with attributes:
@@ -1689,10 +1693,11 @@ TapResponse wg_session_process_tap(capture_file *cfile, MapInput input)
     char tapbuf[32];
     const char *tap_filter;
     const char *tok_tap;
+    const char *ignore_filter;
     void *tap_data = NULL;
     GFreeFunc tap_free = NULL;
     GString *tap_error = NULL;
-    guint32 flags = 0;
+    guint32 flags = TL_REQUIRES_NOTHING;
 
     snprintf(tapbuf, sizeof(tapbuf), "tap%d", i);
     if (input.find(tapbuf) == input.end())
@@ -1701,6 +1706,10 @@ TapResponse wg_session_process_tap(capture_file *cfile, MapInput input)
     tok_tap = input[tapbuf].c_str();
     snprintf(tapbuf, sizeof(tapbuf), "filter%d", i);
     tap_filter = input[tapbuf].c_str();
+
+    ignore_filter = input["ignore_filter"].c_str();
+    if (ignore_filter && !strcmp(ignore_filter, "1"))
+      flags |= TL_IGNORE_DISPLAY_FILTER;
 
     if (!strncmp(tok_tap, "conv:", 5) || !strncmp(tok_tap, "endpt:", 6))
     {

--- a/lib/wiregasm/lib.cpp
+++ b/lib/wiregasm/lib.cpp
@@ -1665,10 +1665,6 @@ wg_session_process_tap_conv_cb(void *tapdata)
  *   (m) tap0               - First tap request
  *   (o) tap1...tap15       - Other tap requests
  *   (o) filter0...filter15 - Filter for each tap
- *   (o) ignore_filter      - set to "1" if you want to be returned all
- *                            packets, even ones that do not pass the filter.
- *                            The packets will be marked as "filtered" in the
- *                            output.
  *
  * Output object with attributes:
  *   (m) taps  - array of object with attributes:
@@ -1693,11 +1689,10 @@ TapResponse wg_session_process_tap(capture_file *cfile, MapInput input)
     char tapbuf[32];
     const char *tap_filter;
     const char *tok_tap;
-    const char *ignore_filter;
     void *tap_data = NULL;
     GFreeFunc tap_free = NULL;
     GString *tap_error = NULL;
-    guint32 flags = TL_REQUIRES_NOTHING;
+    guint32 flags = TL_IGNORE_DISPLAY_FILTER;
 
     snprintf(tapbuf, sizeof(tapbuf), "tap%d", i);
     if (input.find(tapbuf) == input.end())
@@ -1706,10 +1701,6 @@ TapResponse wg_session_process_tap(capture_file *cfile, MapInput input)
     tok_tap = input[tapbuf].c_str();
     snprintf(tapbuf, sizeof(tapbuf), "filter%d", i);
     tap_filter = input[tapbuf].c_str();
-
-    ignore_filter = input["ignore_filter"].c_str();
-    if (ignore_filter && !strcmp(ignore_filter, "1"))
-      flags |= TL_IGNORE_DISPLAY_FILTER;
 
     if (!strncmp(tok_tap, "conv:", 5) || !strncmp(tok_tap, "endpt:", 6))
     {

--- a/lib/wiregasm/wiregasm.h
+++ b/lib/wiregasm/wiregasm.h
@@ -6,6 +6,7 @@
 #include <glib.h>
 #include <wireshark/cfile.h>
 #include <map>
+#include <epan/conversation_table.h>
 
 using namespace std;
 
@@ -134,27 +135,39 @@ struct GeoIp {
 };
 
 struct Conversation {
-  string saddr;
-  string daddr;
-  string sport;
-  string dport;
-  unsigned txf;
-  unsigned txb;
-  unsigned rxf;
-  unsigned rxb;
-  double start;
-  double stop;
-  string filter;
+  string saddr;  // source address
+  string daddr;  // destination address
+  string sport;  // source port
+  string dport;  // destination port
+  int conv_id;  // conversation id
+  unsigned txf;  // number of transmitted frames
+  unsigned txb;  // number of transmitted bytes
+  unsigned rxf;  // number of received frames
+  unsigned rxb;  // number of received bytes
+  unsigned tx_frames_total;  // number of transmitted frames total
+  unsigned rx_frames_total;  // number of received frames total
+  unsigned tx_bytes_total;  // number of transmitted bytes total
+  unsigned rx_bytes_total; // number of received bytes total
+  double start;  // relative start time for the conversation
+  double stop;  // relative stop time for the conversation
+  double start_abs_time;  // absolute start time for the conversation
+  bool filtered;  // whether the entry contains only filtered data
+  string filter;  // filter string
 };
 
 struct Host {
-  string host;
-  string port;
-  unsigned txf;
-  unsigned txb;
-  unsigned rxf;
-  unsigned rxb;
-  string filter;
+  string host;  // host address
+  string port;  // host port
+  unsigned txf;  // number of transmitted frames
+  unsigned txb;  // number of transmitted bytes
+  unsigned rxf;  // number of received frames
+  unsigned rxb;  // number of received bytes
+  unsigned tx_frames_total;  // number of transmitted frames total
+  unsigned rx_frames_total;  // number of received frames total
+  unsigned tx_bytes_total;  // number of transmitted bytes total
+  unsigned rx_bytes_total;  // number of received bytes total
+  bool filtered;  // whether the entry contains only filtered data
+  string filter;  // filter string
 };
 
 struct ExportObject

--- a/lib/wiregasm/wiregasm.h
+++ b/lib/wiregasm/wiregasm.h
@@ -6,7 +6,6 @@
 #include <glib.h>
 #include <wireshark/cfile.h>
 #include <map>
-#include <epan/conversation_table.h>
 
 using namespace std;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -558,6 +558,73 @@ describe("Wiregasm Library - Tap", () => {
     });
   });
 
+  test("tap0 conv:TCP with filter and ignore_filter flag", async () => {
+    const data = await fs.readFile("samples/http.cap");
+    const ret = wg.load("http.cap", data);
+    expect(ret.code).toEqual(0);
+    const res = wg.tap({
+      tap0: "conv:TCP",
+      filter0: "ip.addr==145.254.160.237 && tcp.port==3372",
+      ignore_filter: "1",
+    });
+    expect(res).toStrictEqual({
+      error: "",
+      taps: [
+        {
+          convs: [
+            {
+              conv_id: 0,
+              daddr: "65.208.228.223",
+              dport: "80",
+              filter:
+                "ip.addr==145.254.160.237 && tcp.port==3372 && ip.addr==65.208.228.223 && tcp.port==80",
+              filtered: false,
+              rx_bytes_total: 19344,
+              rx_frames_total: 18,
+              rxb: 19344,
+              rxf: 18,
+              saddr: "145.254.160.237",
+              sport: "3372",
+              start: 0,
+              start_abs_time: 1084443427.311224,
+              stop: 30.393704,
+              tx_bytes_total: 1351,
+              tx_frames_total: 16,
+              txb: 1351,
+              txf: 16,
+            },
+            {
+              conv_id: 1,
+              daddr: "216.239.59.99",
+              dport: "80",
+              filter:
+                "ip.addr==145.254.160.237 && tcp.port==3371 && ip.addr==216.239.59.99 && tcp.port==80",
+              filtered: true,
+              rx_bytes_total: 3236,
+              rx_frames_total: 4,
+              rxb: 0,
+              rxf: 0,
+              saddr: "145.254.160.237",
+              sport: "3371",
+              start: 2.984291,
+              start_abs_time: 1084443430.295515,
+              stop: 4.776868,
+              tx_bytes_total: 883,
+              tx_frames_total: 3,
+              txb: 0,
+              txf: 0,
+            },
+          ],
+          hosts: [],
+          geoip: false,
+          proto: "TCP",
+          tap: "conv:TCP",
+          type: "conv",
+        },
+      ],
+    });
+  });
+
   test("tap0 conv:TCP with filter", async () => {
     const data = await fs.readFile("samples/http.cap");
     const ret = wg.load("http.cap", data);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -261,41 +261,154 @@ describe("Wiregasm Library - Export Objects", () => {
     expect(second_file.download.file).toBe("download.html");
     expect(second_file.error).toBe("");
   });
+});
 
-  test("tap0 endpt:Ethernet works", async () => {
+describe("Wiregasm Library - Tap", () => {
+  const wg = new Wiregasm();
+
+  beforeAll(() => {
+    return wg.init(loadWiregasm, buildTestOverrides());
+  });
+
+  afterAll(() => {
+    wg.destroy();
+  });
+
+  test("tap0 endpt:UDP works", async () => {
     const data = await fs.readFile("samples/http.cap");
     const ret = wg.load("http.cap", data);
     expect(ret.code).toEqual(0);
-    const res = wg.tap({ tap0: "endpt:Ethernet" });
+    const res = wg.tap({ tap0: "endpt:UDP" });
     expect(res).toStrictEqual({
       error: "",
       taps: [
         {
-          convs: [],
           geoip: false,
+          convs: [],
           hosts: [
             {
-              filter: "eth.addr==00:00:01:00:00:00",
-              host: "Xerox_00:00:00",
-              port: "",
+              filter: "ip.addr==145.254.160.237 && udp.port==3009",
+              filtered: false,
+              host: "145.254.160.237",
+              port: "3009",
+              rx_bytes_total: 188,
+              rx_frames_total: 1,
+              rxb: 188,
+              rxf: 1,
+              tx_bytes_total: 89,
+              tx_frames_total: 1,
+              txb: 89,
+              txf: 1,
+            },
+            {
+              filter: "ip.addr==145.253.2.203 && udp.port==53",
+              filtered: false,
+              host: "145.253.2.203",
+              port: "53",
+              rx_bytes_total: 89,
+              rx_frames_total: 1,
+              rxb: 89,
+              rxf: 1,
+              tx_bytes_total: 188,
+              tx_frames_total: 1,
+              txb: 188,
+              txf: 1,
+            },
+          ],
+          proto: "UDP",
+          tap: "endpt:UDP",
+          type: "host",
+        },
+      ],
+    });
+  });
+
+  test("tap0 endpt:UDP with filter works", async () => {
+    const data = await fs.readFile("samples/http.cap");
+    const ret = wg.load("http.cap", data);
+    expect(ret.code).toEqual(0);
+    const res = wg.tap({ tap0: "endpt:UDP", filter0: "udp.port==53" });
+    expect(res).toStrictEqual({
+      error: "",
+      taps: [
+        {
+          geoip: false,
+          convs: [],
+          hosts: [
+            {
+              filter: "ip.addr==145.254.160.237 && udp.port==3009",
+              filtered: false,
+              host: "145.254.160.237",
+              port: "3009",
+              rx_bytes_total: 188,
+              rx_frames_total: 1,
+              rxb: 188,
+              rxf: 1,
+              tx_bytes_total: 89,
+              tx_frames_total: 1,
+              txb: 89,
+              txf: 1,
+            },
+            {
+              filter: "ip.addr==145.253.2.203 && udp.port==53",
+              filtered: false,
+              host: "145.253.2.203",
+              port: "53",
+              rx_bytes_total: 89,
+              rx_frames_total: 1,
+              rxb: 89,
+              rxf: 1,
+              tx_bytes_total: 188,
+              tx_frames_total: 1,
+              txb: 188,
+              txf: 1,
+            },
+          ],
+          proto: "UDP",
+          tap: "endpt:UDP",
+          type: "host",
+        },
+      ],
+    });
+  });
+
+  test("tap0 conv:Ethernet works", async () => {
+    const data = await fs.readFile("samples/http.cap");
+    const ret = wg.load("http.cap", data);
+    expect(ret.code).toEqual(0);
+    const res = wg.tap({ tap0: "conv:Ethernet" });
+    expect(res).toStrictEqual({
+      error: "",
+      taps: [
+        {
+          convs: [
+            {
+              conv_id: -1,
+              daddr: "fe:ff:20:00:01:00",
+              dport: "",
+              filter:
+                "eth.addr==00:00:01:00:00:00 && eth.addr==fe:ff:20:00:01:00",
+              filtered: false,
+              rx_bytes_total: 22768,
+              rx_frames_total: 23,
               rxb: 22768,
               rxf: 23,
+              saddr: "00:00:01:00:00:00",
+              sport: "",
+              start: 0,
+              start_abs_time: 1084443427.311224,
+              stop: 30.393704,
+              tx_bytes_total: 2323,
+              tx_frames_total: 20,
               txb: 2323,
               txf: 20,
             },
-            {
-              filter: "eth.addr==fe:ff:20:00:01:00",
-              host: "fe:ff:20:00:01:00",
-              port: "",
-              rxb: 2323,
-              rxf: 20,
-              txb: 22768,
-              txf: 23,
-            },
           ],
+          hosts: [],
+          geoip: false,
           proto: "Ethernet",
-          tap: "endpt:Ethernet",
-          type: "host",
+          tap: "conv:Ethernet",
+          type: "conv",
         },
       ],
     });
@@ -312,6 +425,7 @@ describe("Wiregasm Library - Export Objects", () => {
         {
           convs: [
             {
+              conv_id: -1,
               daddr: "65.208.228.223",
               dport: "",
               filter: "ip.addr==145.254.160.237 && ip.addr==65.208.228.223",
@@ -323,8 +437,15 @@ describe("Wiregasm Library - Export Objects", () => {
               stop: 30.393704,
               txb: 1351,
               txf: 16,
+              filtered: false,
+              rx_bytes_total: 19344,
+              rx_frames_total: 18,
+              start_abs_time: 1084443427.311224,
+              tx_bytes_total: 1351,
+              tx_frames_total: 16,
             },
             {
+              conv_id: -1,
               daddr: "145.253.2.203",
               dport: "",
               filter: "ip.addr==145.254.160.237 && ip.addr==145.253.2.203",
@@ -336,8 +457,15 @@ describe("Wiregasm Library - Export Objects", () => {
               stop: 2.91419,
               txb: 89,
               txf: 1,
+              filtered: false,
+              rx_bytes_total: 188,
+              rx_frames_total: 1,
+              start_abs_time: 1084443429.864896,
+              tx_bytes_total: 89,
+              tx_frames_total: 1,
             },
             {
+              conv_id: -1,
               daddr: "216.239.59.99",
               dport: "",
               filter: "ip.addr==145.254.160.237 && ip.addr==216.239.59.99",
@@ -349,12 +477,126 @@ describe("Wiregasm Library - Export Objects", () => {
               stop: 4.776868,
               txb: 883,
               txf: 3,
+              filtered: false,
+              rx_bytes_total: 3236,
+              rx_frames_total: 4,
+              start_abs_time: 1084443430.295515,
+              tx_bytes_total: 883,
+              tx_frames_total: 3,
             },
           ],
           geoip: false,
           hosts: [],
           proto: "IPv4",
           tap: "conv:IPv4",
+          type: "conv",
+        },
+      ],
+    });
+  });
+
+  test("tap0 conv:TCP has proper stream id", async () => {
+    const data = await fs.readFile("samples/http.cap");
+    const ret = wg.load("http.cap", data);
+    expect(ret.code).toEqual(0);
+    const res = wg.tap({ tap0: "conv:TCP" });
+    expect(res).toStrictEqual({
+      error: "",
+      taps: [
+        {
+          convs: [
+            {
+              conv_id: 0,
+              daddr: "65.208.228.223",
+              dport: "80",
+              filter:
+                "ip.addr==145.254.160.237 && tcp.port==3372 && ip.addr==65.208.228.223 && tcp.port==80",
+              filtered: false,
+              rx_bytes_total: 19344,
+              rx_frames_total: 18,
+              rxb: 19344,
+              rxf: 18,
+              saddr: "145.254.160.237",
+              sport: "3372",
+              start: 0,
+              start_abs_time: 1084443427.311224,
+              stop: 30.393704,
+              tx_bytes_total: 1351,
+              tx_frames_total: 16,
+              txb: 1351,
+              txf: 16,
+            },
+            {
+              conv_id: 1,
+              daddr: "216.239.59.99",
+              dport: "80",
+              filter:
+                "ip.addr==145.254.160.237 && tcp.port==3371 && ip.addr==216.239.59.99 && tcp.port==80",
+              filtered: false,
+              rx_bytes_total: 3236,
+              rx_frames_total: 4,
+              rxb: 3236,
+              rxf: 4,
+              saddr: "145.254.160.237",
+              sport: "3371",
+              start: 2.984291,
+              start_abs_time: 1084443430.295515,
+              stop: 4.776868,
+              tx_bytes_total: 883,
+              tx_frames_total: 3,
+              txb: 883,
+              txf: 3,
+            },
+          ],
+          hosts: [],
+          geoip: false,
+          proto: "TCP",
+          tap: "conv:TCP",
+          type: "conv",
+        },
+      ],
+    });
+  });
+
+  test("tap0 conv:TCP with filter", async () => {
+    const data = await fs.readFile("samples/http.cap");
+    const ret = wg.load("http.cap", data);
+    expect(ret.code).toEqual(0);
+    const res = wg.tap({
+      tap0: "conv:TCP",
+      filter0: "ip.addr==145.254.160.237 && tcp.port==3372",
+    });
+    expect(res).toStrictEqual({
+      error: "",
+      taps: [
+        {
+          convs: [
+            {
+              conv_id: 0,
+              daddr: "65.208.228.223",
+              dport: "80",
+              filter:
+                "ip.addr==145.254.160.237 && tcp.port==3372 && ip.addr==65.208.228.223 && tcp.port==80",
+              filtered: false,
+              rx_bytes_total: 19344,
+              rx_frames_total: 18,
+              rxb: 19344,
+              rxf: 18,
+              saddr: "145.254.160.237",
+              sport: "3372",
+              start: 0,
+              start_abs_time: 1084443427.311224,
+              stop: 30.393704,
+              tx_bytes_total: 1351,
+              tx_frames_total: 16,
+              txb: 1351,
+              txf: 16,
+            },
+          ],
+          hosts: [],
+          geoip: false,
+          proto: "TCP",
+          tap: "conv:TCP",
           type: "conv",
         },
       ],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -558,14 +558,13 @@ describe("Wiregasm Library - Tap", () => {
     });
   });
 
-  test("tap0 conv:TCP with filter and ignore_filter flag", async () => {
+  test("tap0 conv:Ethernet with filter", async () => {
     const data = await fs.readFile("samples/http.cap");
     const ret = wg.load("http.cap", data);
     expect(ret.code).toEqual(0);
     const res = wg.tap({
-      tap0: "conv:TCP",
+      tap0: "conv:Ethernet",
       filter0: "ip.addr==145.254.160.237 && tcp.port==3372",
-      ignore_filter: "1",
     });
     expect(res).toStrictEqual({
       error: "",
@@ -573,65 +572,43 @@ describe("Wiregasm Library - Tap", () => {
         {
           convs: [
             {
-              conv_id: 0,
-              daddr: "65.208.228.223",
-              dport: "80",
+              conv_id: -1,
+              daddr: "fe:ff:20:00:01:00",
+              dport: "",
               filter:
-                "ip.addr==145.254.160.237 && tcp.port==3372 && ip.addr==65.208.228.223 && tcp.port==80",
+                "eth.addr==00:00:01:00:00:00 && eth.addr==fe:ff:20:00:01:00",
               filtered: false,
-              rx_bytes_total: 19344,
-              rx_frames_total: 18,
+              rx_bytes_total: 22768,
+              rx_frames_total: 23,
               rxb: 19344,
               rxf: 18,
-              saddr: "145.254.160.237",
-              sport: "3372",
+              saddr: "00:00:01:00:00:00",
+              sport: "",
               start: 0,
               start_abs_time: 1084443427.311224,
               stop: 30.393704,
-              tx_bytes_total: 1351,
-              tx_frames_total: 16,
+              tx_bytes_total: 2323,
+              tx_frames_total: 20,
               txb: 1351,
               txf: 16,
-            },
-            {
-              conv_id: 1,
-              daddr: "216.239.59.99",
-              dport: "80",
-              filter:
-                "ip.addr==145.254.160.237 && tcp.port==3371 && ip.addr==216.239.59.99 && tcp.port==80",
-              filtered: true,
-              rx_bytes_total: 3236,
-              rx_frames_total: 4,
-              rxb: 0,
-              rxf: 0,
-              saddr: "145.254.160.237",
-              sport: "3371",
-              start: 2.984291,
-              start_abs_time: 1084443430.295515,
-              stop: 4.776868,
-              tx_bytes_total: 883,
-              tx_frames_total: 3,
-              txb: 0,
-              txf: 0,
             },
           ],
           hosts: [],
           geoip: false,
-          proto: "TCP",
-          tap: "conv:TCP",
+          proto: "Ethernet",
+          tap: "conv:Ethernet",
           type: "conv",
         },
       ],
     });
   });
 
-  test("tap0 conv:TCP with filter", async () => {
+  test("tap0 conv:Ethernet without filter", async () => {
     const data = await fs.readFile("samples/http.cap");
     const ret = wg.load("http.cap", data);
     expect(ret.code).toEqual(0);
     const res = wg.tap({
-      tap0: "conv:TCP",
-      filter0: "ip.addr==145.254.160.237 && tcp.port==3372",
+      tap0: "conv:Ethernet",
     });
     expect(res).toStrictEqual({
       error: "",
@@ -639,31 +616,31 @@ describe("Wiregasm Library - Tap", () => {
         {
           convs: [
             {
-              conv_id: 0,
-              daddr: "65.208.228.223",
-              dport: "80",
+              conv_id: -1,
+              daddr: "fe:ff:20:00:01:00",
+              dport: "",
               filter:
-                "ip.addr==145.254.160.237 && tcp.port==3372 && ip.addr==65.208.228.223 && tcp.port==80",
+                "eth.addr==00:00:01:00:00:00 && eth.addr==fe:ff:20:00:01:00",
               filtered: false,
-              rx_bytes_total: 19344,
-              rx_frames_total: 18,
-              rxb: 19344,
-              rxf: 18,
-              saddr: "145.254.160.237",
-              sport: "3372",
+              rx_bytes_total: 22768,
+              rx_frames_total: 23,
+              rxb: 22768,
+              rxf: 23,
+              saddr: "00:00:01:00:00:00",
+              sport: "",
               start: 0,
               start_abs_time: 1084443427.311224,
               stop: 30.393704,
-              tx_bytes_total: 1351,
-              tx_frames_total: 16,
-              txb: 1351,
-              txf: 16,
+              tx_bytes_total: 2323,
+              tx_frames_total: 20,
+              txb: 2323,
+              txf: 20,
             },
           ],
           hosts: [],
           geoip: false,
-          proto: "TCP",
-          tap: "conv:TCP",
+          proto: "Ethernet",
+          tap: "conv:Ethernet",
           type: "conv",
         },
       ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,10 @@ import {
 } from "./types";
 import { preferenceSetCodeToError, vectorToArray } from "./utils";
 
-const ALLOWED_TAP_KEYS = new Set(
-  Array.from({ length: 15 }, (_, i) => `tap${i}`)
-);
+const ALLOWED_TAP_KEYS = new Set([
+  ...Array.from({ length: 15 }, (_, i) => `tap${i}`),
+  ...Array.from({ length: 15 }, (_, i) => `filter${i}`),
+]);
 
 const ALLOWED_GRAPH_KEYS = new Set([
   "filter",
@@ -129,7 +130,11 @@ export class Wiregasm {
       throw new Error("tap0 is mandatory.");
     }
     if (!Object.keys(taps).every((k) => ALLOWED_TAP_KEYS.has(k))) {
-      throw new Error(`Invalid arguments. Only tap0..tap15 keys are allowed.`);
+      throw new Error(
+        `Invalid arguments. Allowed keys are: ${Array.from(
+          ALLOWED_GRAPH_KEYS
+        ).join(", ")}.`
+      );
     }
 
     const args = new this.lib.MapInput();

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ import { preferenceSetCodeToError, vectorToArray } from "./utils";
 const ALLOWED_TAP_KEYS = new Set([
   ...Array.from({ length: 15 }, (_, i) => `tap${i}`),
   ...Array.from({ length: 15 }, (_, i) => `filter${i}`),
-  "ignore_filter",
 ]);
 
 const ALLOWED_GRAPH_KEYS = new Set([

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { preferenceSetCodeToError, vectorToArray } from "./utils";
 const ALLOWED_TAP_KEYS = new Set([
   ...Array.from({ length: 15 }, (_, i) => `tap${i}`),
   ...Array.from({ length: 15 }, (_, i) => `filter${i}`),
+  "ignore_filter",
 ]);
 
 const ALLOWED_GRAPH_KEYS = new Set([

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,13 @@ export interface Conversation {
   start: number;
   stop: number;
   filter: string;
+  tx_bytes_total: number;
+  tx_frames_total: number;
+  rx_bytes_total: number;
+  rx_frames_total: number;
+  filtered: boolean;
+  conv_id: number;
+  start_abs_time: number;
 }
 
 export interface Host {
@@ -203,6 +210,11 @@ export interface Host {
   rxf: number;
   rxb: number;
   filter: string;
+  tx_bytes_total: number;
+  tx_frames_total: number;
+  rx_bytes_total: number;
+  rx_frames_total: number;
+  filtered: boolean;
 }
 
 export interface TapResponseBase {
@@ -222,7 +234,6 @@ export interface TapConvResponse extends TapResponseBase {
 }
 
 export type TapResponse = TapExportObjectResponse | TapConvResponse;
-
 
 export interface IoGraphResult {
   error: string;


### PR DESCRIPTION
Extends conversations tap with extra information (conv_id/stream id, total frames and bytes, abs time).
Disables address name resolution (f.i, before: "Xerox_00:00:00", after: "00:00:01:00:00:00").
Added support for filters for each tap, similar to the io graph api.