### PR TITLE
chore: update workflows to node-22 and use trusted publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,14 +10,21 @@ jobs:
   release:
     runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'good-tools/wiregasm' }}
+    permissions:
+      contents: write
+      id-token: write
     steps:
     - uses: actions/checkout@v3
 
     - name: Configure Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 22
         cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Update npm for Trusted Publishers
+      run: npm install -g npm@latest
 
     - name: Download artifacts
       uses: dawidd6/action-download-artifact@v2
@@ -36,5 +43,5 @@ jobs:
       id: release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NPM_CONFIG_PROVENANCE: true
       run: npx semantic-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    
+
+    - name: Configure Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 22
+        cache: 'npm'
+
     - name: Stash old path
       run: echo "OLD_PATH=$PATH" >> "${GITHUB_ENV}"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@goodtools/wiregasm",
-  "version": "1.6.1",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@goodtools/wiregasm",
-      "version": "1.6.1",
+      "version": "1.9.0",
       "license": "GPLV2",
       "devDependencies": {
         "@parcel/packager-ts": "^2.8.2",
         "@parcel/transformer-typescript-types": "^2.8.2",
         "@semantic-release/git": "^10.0.1",
         "@types/jest": "^29.2.5",
-        "@types/node": "^18.11.18",
+        "@types/node": "^22.19.11",
         "@types/pako": "^2.0.0",
         "@typescript-eslint/eslint-plugin": "^5.48.1",
         "@typescript-eslint/parser": "^5.48.1",
@@ -3104,10 +3104,14 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -12897,6 +12901,13 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unique-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@parcel/transformer-typescript-types": "^2.8.2",
     "@semantic-release/git": "^10.0.1",
     "@types/jest": "^29.2.5",
-    "@types/node": "^18.11.18",
+    "@types/node": "^22.19.11",
     "@types/pako": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.48.1",
     "@typescript-eslint/parser": "^5.48.1",


### PR DESCRIPTION
Switches npm publishing from using an `NPM_TOKEN` secret to OIDC-based Trusted Publishing by adding `id-token: write` permissions, configuring the registry URL, and setting `NPM_CONFIG_PROVENANCE`. Also pins both CI and CD workflows to Node 22 (up from 18) with explicit `setup-node` steps, and updates `@types/node` to match.